### PR TITLE
Add smol-based P2P prototype and business plan

### DIFF
--- a/BUSINESS_PLAN.md
+++ b/BUSINESS_PLAN.md
@@ -1,0 +1,28 @@
+# Business Plan for P2P IOU Marketplace
+
+## Mission
+Create a decentralised marketplace where users can trade goods and services using a mutual credit (IOU) system instead of blockchain.
+
+## Value Proposition
+- Instant peer-to-peer settlement.
+- Cryptographically secure messages and signed IOUs.
+- No central fees; cooperative ownership model.
+
+## Revenue Streams
+- **Voluntary commissions** on transactions to support development.
+- **Premium features** such as encrypted cloud backups and analytics for community markets.
+- **Community fund** for open-source maintenance and security audits.
+
+## Funding Model
+- Users can obtain cooperative shares, giving them voting rights on project direction.
+- Donations funnelled into a transparent fund used for bug bounties and new features.
+
+## Go-to-Market
+1. Pilot with local cooperatives and barter groups.
+2. Encourage referrals with non-monetary rewards.
+3. Publish the protocol and libraries as open source to foster third‑party apps.
+
+## Roadmap
+- Enhance the `smol-iroh` networking core with encryption and peer discovery.
+- Provide mobile bindings (Android/iOS) for the IOU app.
+- Launch community governance portal for decision making.

--- a/iou-app/Cargo.toml
+++ b/iou-app/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "iou-app"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+
+smol = "1"
+smol-iroh = { path = "../smol-iroh" }

--- a/iou-app/src/main.rs
+++ b/iou-app/src/main.rs
@@ -1,0 +1,22 @@
+use smol_iroh::{NodeConfig, P2PNode};
+use smol::Timer;
+use std::time::Duration;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    smol::block_on(async {
+        let server = P2PNode::new(NodeConfig {
+            listen_addr: "127.0.0.1:34567".into(),
+            node_id: "srv".into(),
+        });
+        smol::spawn(server.start()).detach();
+        Timer::after(Duration::from_millis(100)).await;
+        let client = P2PNode::new(NodeConfig {
+            listen_addr: "0.0.0.0:0".into(),
+            node_id: "cli".into(),
+        });
+        let msg = b"demo message";
+        let resp = client.connect("127.0.0.1:34567", msg).await?;
+        println!("received: {}", String::from_utf8_lossy(&resp));
+        Ok(())
+    })
+}

--- a/smol-iroh/Cargo.toml
+++ b/smol-iroh/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "smol-iroh"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+
+smol = "1"

--- a/smol-iroh/src/lib.rs
+++ b/smol-iroh/src/lib.rs
@@ -1,0 +1,61 @@
+use smol::io::{self, AsyncReadExt, AsyncWriteExt};
+use smol::net::{TcpListener, TcpStream};
+
+#[derive(Debug, Clone)]
+pub struct NodeConfig {
+    pub listen_addr: String,
+    pub node_id: String,
+}
+
+pub struct P2PNode {
+    cfg: NodeConfig,
+}
+
+impl P2PNode {
+    pub fn new(cfg: NodeConfig) -> Self {
+        Self { cfg }
+    }
+
+    pub async fn start(&self) -> io::Result<()> {
+        let listener = TcpListener::bind(&self.cfg.listen_addr).await?;
+        loop {
+            let (mut stream, _) = listener.accept().await?;
+            smol::spawn(async move {
+                let mut buf = vec![0u8; 1024];
+                if let Ok(n) = stream.read(&mut buf).await {
+                    let _ = stream.write_all(&buf[..n]).await;
+                }
+            })
+            .detach();
+        }
+    }
+
+    pub async fn connect(&self, target: &str, msg: &[u8]) -> io::Result<Vec<u8>> {
+        let mut stream = TcpStream::connect(target).await?;
+        stream.write_all(msg).await?;
+        let mut buf = Vec::new();
+        stream.read_to_end(&mut buf).await?;
+        Ok(buf)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use smol::Timer;
+    use std::time::Duration;
+
+    #[test]
+    fn echo_roundtrip() {
+        smol::block_on(async {
+            let addr = "127.0.0.1:23456";
+            let server = P2PNode::new(NodeConfig { listen_addr: addr.into(), node_id: "srv".into() });
+            smol::spawn(server.start()).detach();
+            Timer::after(Duration::from_millis(100)).await;
+            let client = P2PNode::new(NodeConfig { listen_addr: "0.0.0.0:0".into(), node_id: "cli".into() });
+            let msg = b"ping";
+            let res = client.connect(addr, msg).await.unwrap();
+            assert_eq!(res, msg);
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- add `smol-iroh` crate implementing a minimal async P2P node using the `smol` runtime
- add `iou-app` example binary demonstrating a basic IOU message exchange
- document an open-source business plan for a mutual-credit marketplace

## Testing
- `cargo test` *(fails: spurious network error (CONNECT tunnel failed, response 403))*

------
https://chatgpt.com/codex/tasks/task_e_6892f452ba8083319fd03d023091b2a5